### PR TITLE
Update any references to 'tflannag' -> 'operator-first'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# quay.io/tflannag/curator-bundle:$VERSION and quay.io/tflannag/curator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/tflannag/curator
+# quay.io/operate-first/curator-operator-bundle:$VERSION and quay.io/operate-first/curator-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= quay.io/operate-first/curator-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/bundle/manifests/curator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/curator-operator.clusterserviceversion.yaml
@@ -154,7 +154,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/tflannag/curator:v0.0.1
+                image: quay.io/operate-first/curator-operator:v0.0.1
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/tflannag/curator
+  newName: quay.io/operate-first/curator-operator
   newTag: v0.0.1


### PR DESCRIPTION
Follow-up to #8 which handled updating the requisite code changes now that the curator-operator repository has been transferred from my personal account to the operator-first organization.

Signed-off-by: timflannagan <timflannagan@gmail.com>