### PR TITLE
.github: Bump the golangci-lint action in the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Run linting checks
       uses: "golangci/golangci-lint-action@v2"
       with:
-        version: "v1.43"
+        version: "v1.45.2"
 
   olm-bundle:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates the golangci-linter's GHA action from the problematic v1.43 to v1.45.2 that plays nicely with repositories using Go 1.17.

Signed-off-by: timflannagan <timflannagan@gmail.com>